### PR TITLE
evaluationWindowSize no more evaluates to zero due to decimal divison

### DIFF
--- a/MINAS-BR_jan2021/src/main/Main.java
+++ b/MINAS-BR_jan2021/src/main/Main.java
@@ -281,7 +281,7 @@ public class Main {
         FileWriter fileOff = new FileWriter(new File(outputDirectory + "/faseOfflineInfo.txt"), false); //Armazena informações da fase online
         FileWriter fileOut = new FileWriter(new File(outputDirectory + "/results.txt"), false); //Armazena informações da fase de treinamento
         
-        int evaluationWindowSize = (int) Math.ceil(test.size()/50);
+        int evaluationWindowSize = (int) Math.ceil(test.size()/50.0);
         
         OfflinePhase treino = new OfflinePhase(train, k_ini, fileOff, outputDirectory);
         Model model = treino.getModel();


### PR DESCRIPTION
When the dataset test.size() was lower than 50, due to integer division result was always zero.

Our fix fixes this.